### PR TITLE
Broadcast event with the definition of a deleted widget

### DIFF
--- a/src/scripts/directives/adf-widget.directive.js
+++ b/src/scripts/directives/adf-widget.directive.js
@@ -112,7 +112,7 @@ angular.module('adf')
             }
           }
           $element.remove();
-          $rootScope.$broadcast('adfWidgetRemovedFromColumn');
+          $rootScope.$broadcast('adfWidgetRemovedFromColumn', definition);
         };
 
         $scope.remove = function() {

--- a/test/unit/directives/adf-widget.directive.spec.js
+++ b/test/unit/directives/adf-widget.directive.spec.js
@@ -214,6 +214,16 @@ describe('widget directive tests', function() {
       // expect widget is not removed
       expect($scope.column.widgets.length).toBe(1);
     });
+
+    it('should broadcast event with the definition of the deleted', function() {
+      spyOn($rootScope, '$broadcast').and.returnValue({preventDefault: true});
+      $scope.options.enableConfirmDelete = false;
+      removeWidget();
+
+      var definition = jasmine.objectContaining($scope.column.widgets[0]);
+      expect($rootScope.$broadcast).toHaveBeenCalledWith('adfWidgetRemovedFromColumn', definition);
+    });
+
   });
 
   it('should open and close full screen dialog', function() {


### PR DESCRIPTION
It is useful when developers want to unsubscribe some widget specific events whose name is associated with widget id